### PR TITLE
fix: add types/model-viewer.d.ts to the TS build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       "@app/*": ["app/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/model-viewer.d.ts
+++ b/types/model-viewer.d.ts
@@ -1,30 +1,39 @@
-declare namespace JSX {
-  interface IntrinsicElements {
-    "model-viewer": React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement>,
-      HTMLElement
-    > & {
-      src?: string;
-      alt?: string;
-      poster?: string;
-      autoplay?: boolean;
-      ar?: boolean;
-      exposure?: string | number;
-      "camera-controls"?: boolean;
-      "auto-rotate"?: boolean;
-      "interaction-prompt"?: string;
-      "environment-image"?: string;
-      "shadow-intensity"?: string | number;
-      "shadow-softness"?: string | number;
-      "camera-orbit"?: string;
-      "camera-target"?: string;
-      "field-of-view"?: string;
-      "min-field-of-view"?: string;
-      "max-field-of-view"?: string;
-      "ar-modes"?: string;
-      "touch-action"?: string;
-      "disable-zoom"?: boolean;
-      "tone-mapping"?: string;
-    };
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+
+type ModelViewerElement = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
+  src?: string;
+  alt?: string;
+  poster?: string;
+  autoplay?: boolean;
+  ar?: boolean;
+  exposure?: string | number;
+  "camera-controls"?: boolean;
+  "auto-rotate"?: boolean;
+  "interaction-prompt"?: string;
+  "environment-image"?: string;
+  "shadow-intensity"?: string | number;
+  "shadow-softness"?: string | number;
+  "camera-orbit"?: string;
+  "camera-target"?: string;
+  "field-of-view"?: string;
+  "min-field-of-view"?: string;
+  "max-field-of-view"?: string;
+  "ar-modes"?: string;
+  "touch-action"?: string;
+  "disable-zoom"?: boolean;
+  "tone-mapping"?: string;
+};
+
+declare global {
+  namespace React.JSX {
+    interface IntrinsicElements {
+      "model-viewer": ModelViewerElement;
+    }
+  }
+
+  namespace JSX {
+    interface IntrinsicElements {
+      "model-viewer": ModelViewerElement;
+    }
   }
 }


### PR DESCRIPTION
Added types/model-viewer.d.ts to the TS build by extending both React.JSX and global JSX intrinsic elements with a strongly-typed model-viewer definition. app/baguette/page.tsx no longer needed the hacky alias.
